### PR TITLE
Gracefully handle errors parsing PR titles and notes

### DIFF
--- a/review.py
+++ b/review.py
@@ -193,10 +193,20 @@ def fetch_dependency_prs(
             if repo_filter not in repo:
                 continue
 
-        dependency, from_version, to_version = parse_dependabot_pr_title(pr["title"])
-        notes = parse_dependabot_pr_body(pr["bodyHTML"])
-        status_check_rollup = pr["commits"]["nodes"][0]["commit"]["statusCheckRollup"]
-        package_type = parse_package_type_from_branch_name(pr["headRefName"])
+        try:
+            dependency, from_version, to_version = parse_dependabot_pr_title(
+                pr["title"]
+            )
+            notes = parse_dependabot_pr_body(pr["bodyHTML"])
+            status_check_rollup = pr["commits"]["nodes"][0]["commit"][
+                "statusCheckRollup"
+            ]
+            package_type = parse_package_type_from_branch_name(pr["headRefName"])
+        except ValueError:
+            print(
+                f"Failed to parse dependency details from {pr['url']}", file=sys.stderr
+            )
+            continue
 
         rollup_state = status_check_rollup["state"] if status_check_rollup else None
         if rollup_state == "SUCCESS":


### PR DESCRIPTION
review.py expects PR titles to have the form "Bump {package_name} from {old_version} to {new_version}". This parsing failed when Dependabot created a PR that bumped two packages at once, with the title "Bump {first_package_name} and {second_package_name}".

Handle this type of issue more gracefully by informing the user of the URL of the PR whose info could not be parsed, and continuing with other PRs.