### PR TITLE
Prompt for GitHub API token if `GITHUB_TOKEN` env var is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ with permission to read and merge PRs in the organization you want to query.
 Then in this repository run:
 
 ```sh
-export GITHUB_TOKEN=$TOKEN
 pipenv run review [organization]
 ```
+
+You will be prompted for a [GitHub API
+token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
+If the `GITHUB_TOKEN` environment variable is set, that value will be used.
 
 This will query for open PRs from Dependabot in the organization `organization`,
 which can also be a GitHub username. It will group the updates by package name,

--- a/review.py
+++ b/review.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 from dataclasses import dataclass
 from enum import Enum
+from getpass import getpass
 import json
 import re
 import os
@@ -512,7 +513,10 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    access_token = os.environ["GITHUB_TOKEN"]
+    access_token = os.environ.get("GITHUB_TOKEN")
+    if not access_token:
+        access_token = getpass("GitHub API token: ")
+
     gh_client = GitHubClient(token=access_token)
     t = Terminal()
 


### PR DESCRIPTION
Entering the token via a password prompt avoids the value ending up in shell history.