### PR TITLE
Add `--slack` option to send security alert summary to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ To resolve an alert, you can:
 
    See https://docs.github.com/en/code-security/dependabot/dependabot-alert-rules/about-dependabot-alert-rules
 
+### Slack notifications
+
+If run with the `--slack` flag, the tool will send a report of vulnerabilities
+found to the Slack channel specified using the `SLACK_CHANNEL` environment
+variable. An authentication token for a Slack app must be provided via the
+`SLACK_TOKEN` environment variable. You can create a Slack app at
+https://api.slack.com/apps.
+
 ## Reviewing updates
 
 To review Dependabot dependency update PRs for a user or organization, run:

--- a/dependabot_batch_review/slack.py
+++ b/dependabot_batch_review/slack.py
@@ -9,15 +9,18 @@ class SlackClient:
     def __init__(self, token: str):
         self.token = token
 
-    def post_message(self, channel: str, message: str):
+    def post_message(self, channel_id: str, message: str):
         """
         Post a message to a Slack channel.
 
         See https://api.slack.com/methods/chat.postMessage.
+
+        :param channel_id: Channel ID, available from the bottom of a channel's "About" dialog
+        :param message: Message text using Slack's "mrkdwn" format
         """
 
         body = {
-            "channel": channel,
+            "channel": channel_id,
             "text": message,
         }
         self._call(body)

--- a/dependabot_batch_review/slack.py
+++ b/dependabot_batch_review/slack.py
@@ -1,0 +1,32 @@
+import requests
+
+
+class SlackClient:
+    """
+    Client for posting messages to Slack.
+    """
+
+    def __init__(self, token: str):
+        self.token = token
+
+    def post_message(self, channel: str, message: str):
+        """
+        Post a message to a Slack channel.
+
+        See https://api.slack.com/methods/chat.postMessage.
+        """
+
+        body = {
+            "channel": channel,
+            "text": message,
+        }
+        self._call(body)
+
+    def _call(self, body):
+        rsp = requests.post(
+            "https://slack.com/api/chat.postMessage",
+            json=body,
+            headers={"Authorization": f"Bearer {self.token}"},
+        )
+        rsp.raise_for_status()
+        return rsp.json()


### PR DESCRIPTION
This can be used in a cron job to send regular reports of open vulnerabilities to Slack.

An example of what the generated message looks like:

<img width="782" alt="Dependabot alerts" src="https://github.com/hypothesis/dependabot-batch-review/assets/2458/75f74b99-2ce5-4ead-a52f-24888b454d18">
