### PR TITLE
Add GitHub action that runs alert check weekly

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -1,0 +1,29 @@
+name: Scheduled check for alerts in Hypothesis org
+on:
+  schedule:
+    cron: '30 10 * * 1'
+  workflow_dispatch:
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install pipenv
+        run: |
+          pip install --upgrade pipenv
+          pipenv install --deploy
+
+      - name: Check for alerts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_DEPENDABOT_ALERT_TOKEN }}
+          SLACK_CHANNEL: C062HG8E691
+        run: |
+          pipenv run alerts hypothesis --slack


### PR DESCRIPTION
The Slack channel is currently the #security-alert-bot-test-channel test channel. I will update this once I have verified that it is working.

Part of https://github.com/hypothesis/playbook/issues/1425.