### PR TITLE
Get GitHub token from `gh` tool if installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ It is built on the GitHub [GraphQL API](https://docs.github.com/en/graphql).
 
 ## Authorization
 
-Before using this tool, generate a [GitHub access
-token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+In order of precedence, this tool will obtain a GitHub API token from:
 
-For reviewing security alerts, this token must have permission to query alerts
+ - The `GITHUB_TOKEN` environment variable
+ - The [GitHub CLI](https://cli.github.com) if installed and logged in
+ - Prompting for a token when the tool is run
+
+For reviewing security alerts, the token must have permission to query alerts
 in the target organization/user account. For reviewing updates, this token must
 have permission to read and merge PRs in the target organization/user account.
-
-The token can be passed to the tool by setting the `GITHUB_TOKEN` environment
-variable, or by inputting the token when prompted.
 
 ## Reviewing security alerts
 

--- a/dependabot_batch_review/github_client.py
+++ b/dependabot_batch_review/github_client.py
@@ -2,6 +2,7 @@ from getpass import getpass
 import json
 from typing import Any
 import os
+from subprocess import CalledProcessError, run
 
 import requests
 
@@ -36,10 +37,20 @@ class GitHubClient:
         """
         Initialize an authenticated GitHubClient.
 
-        This will read from the `GITHUB_TOKEN` env var if set, or prompt for
-        a token otherwise.
+        This will read from the `GITHUB_TOKEN` env var if set, query the `gh`
+        command if installed, or prompt otherwise.
         """
         access_token = os.environ.get("GITHUB_TOKEN")
+
+        if not access_token:
+            try:
+                access_token = run(
+                    ["gh", "auth", "token"], check=True, capture_output=True, text=True
+                ).stdout.strip()
+            except CalledProcessError:
+                pass
+
         if not access_token:
             access_token = getpass("GitHub API token: ")
+
         return GitHubClient(access_token)


### PR DESCRIPTION
Use `gh auth token` to get the current access token, if the tool is installed.